### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-latest-python-release-version.yml
+++ b/.github/workflows/update-latest-python-release-version.yml
@@ -100,6 +100,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: update-python-release-version
     if: ${{ needs.update-python-release-version.outputs.version_changed == 'true' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/4](https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `Build Docusaurus` job. Based on the job's functionality, it only needs to read repository contents to build the website and upload artifacts. Therefore, we will set `contents: read` as the minimal required permission. This change will ensure that the job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
