### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,4 +1,6 @@
 name: Test deployment
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/5](https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/5)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required. Since the workflow only needs to read repository contents (e.g., to detect the package manager and install dependencies), the minimal permission `contents: read` should be specified. This ensures that the workflow does not have unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
