### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-latest-python-release-version.yml
+++ b/.github/workflows/update-latest-python-release-version.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-python-release-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/3](https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the `update-python-release-version` job. This block should specify the minimal permissions required for the job to function correctly. Based on the workflow's steps, the job requires `contents: write` to commit and push changes to the repository. All other permissions should be omitted unless explicitly needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
