### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/2](https://github.com/eddiehe99/banzhuren-notifier-docs/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `build` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the `build` job only needs to read repository contents (e.g., to detect the package manager and install dependencies), we will set `contents: read` as the minimal required permission. This ensures that the job cannot perform any unintended write operations.

The `permissions` block will be added directly under the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
